### PR TITLE
Fix toJsonTemplate references

### DIFF
--- a/docs/api/createApp.md
+++ b/docs/api/createApp.md
@@ -69,6 +69,6 @@ The `createApp` function returns an object with the following properties:
 
 - [`createComponent`](createComponent.md)
 - [`toFragment`](toFragment.md)
-- [`toJSONTemplate`](toJsonTemplate.md)
+- [`toJsonTemplate`](toJsonTemplate.md)
 
 [Back to the API list](regor-api.md)

--- a/docs/api/createComponent.md
+++ b/docs/api/createComponent.md
@@ -80,6 +80,6 @@ The `createComponent` function returns a component object with the following pro
 
 - [`createApp`](createApp.md)
 - [`toFragment`](toFragment.md)
-- [`toJSONTemplate`](toJsonTemplate.md)
+- [`toJsonTemplate`](toJsonTemplate.md)
 
 [Back to the API list](regor-api.md)

--- a/docs/api/regorConfig.md
+++ b/docs/api/regorConfig.md
@@ -130,6 +130,6 @@ The `RegorConfig` class provides default configuration values for various proper
 - [`createApp`](createApp.md)
 - [`createComponent`](createComponent.md)
 - [`toFragment`](toFragment.md)
-- [`toJSONTemplate`](toJsonTemplate.md)
+- [`toJsonTemplate`](toJsonTemplate.md)
 
 [Back to the API list](regor-api.md)


### PR DESCRIPTION
## Summary
- update references from `toJSONTemplate` to `toJsonTemplate` in createApp, createComponent, and regorConfig docs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a535171d8832885874a1032de79f7