### PR TITLE
Fix createElement usage in tests

### DIFF
--- a/tests/app/createApp.spec.ts
+++ b/tests/app/createApp.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 import { createApp, ref, html, raw } from '../../src'
 
 test('hello world', () => {
-  const root = document.createElement('<div>')
+  const root = document.createElement('div')
   createApp(
     {
       message: ref('hello world'),
@@ -17,7 +17,7 @@ test('hello world', () => {
 })
 
 test('click counter', () => {
-  const root = document.createElement('<div>')
+  const root = document.createElement('div')
   const count = ref(0)
   createApp(
     {

--- a/tests/app/createComponent.spec.ts
+++ b/tests/app/createComponent.spec.ts
@@ -10,7 +10,7 @@ import {
 import { htmlEqual } from '../common/html-equal'
 
 test('should render components with reactive properties', () => {
-  const root = document.createElement('<div>')
+  const root = document.createElement('div')
 
   const myComponent = createComponent(
     () => ({
@@ -105,7 +105,7 @@ test('should render components with reactive properties', () => {
 })
 
 test('should render empty component', () => {
-  const root = document.createElement('<div>')
+  const root = document.createElement('div')
 
   const myComponent = createComponent(() => ({}), html``)
 
@@ -125,7 +125,7 @@ test('should render empty component', () => {
 })
 
 test('should render nested component with reactive properties', () => {
-  const root = document.createElement('<div>')
+  const root = document.createElement('div')
 
   interface MyApp extends IRegorContext {
     treeItem: Ref<TreeItem>

--- a/tests/directives/r-bind.spec.ts
+++ b/tests/directives/r-bind.spec.ts
@@ -3,7 +3,7 @@ import { createApp, html, raw, ref } from '../../src'
 import { htmlEqual } from '../common/html-equal'
 
 test('should bind reactive attributes.', () => {
-  const root = document.createElement('<div>')
+  const root = document.createElement('div')
   const app = createApp(
     {
       class1: ref('c1'),

--- a/tests/directives/r-for.spec.ts
+++ b/tests/directives/r-for.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 import { createApp, ref, html, raw } from '../../src'
 
 test('should mount the people into reactive divs.', () => {
-  const root = document.createElement('<div>')
+  const root = document.createElement('div')
   const app = createApp(
     {
       people: ref([
@@ -46,7 +46,7 @@ test('should mount the people into reactive divs.', () => {
 })
 
 test('should mount nested r-for.', () => {
-  const root = document.createElement('<div>')
+  const root = document.createElement('div')
   const app = createApp(
     {
       duplicate: ref(10),


### PR DESCRIPTION
## Summary
- remove angle brackets from `document.createElement` calls in tests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684a53ad9d708328b6ec7824b1764af5