### PR TITLE
Rename TemplateOptions interface

### DIFF
--- a/docs/api/createApp.md
+++ b/docs/api/createApp.md
@@ -12,7 +12,7 @@ To create a Regor application, call the `createApp` function with the following 
 
 - `context` (required): The Regor context or scope that defines the application's behavior and data. It can be a context object or a scope created using [`useScope`](#useScope).
 
-- `templateOptions` (optional): An HTML string or object specifying the template for rendering the application. It can include the following properties:
+- `template` (optional): An HTML string or object specifying the template for rendering the application. It can include the following properties:
 
   - `selector` (string, optional): A CSS selector string for the root element of the application. If provided, Regor will attempt to find this element in the DOM.
   - `element` (Element, optional): A reference to the root DOM element of the application. If provided, this element will be used as the root.
@@ -39,7 +39,7 @@ const app = createApp(appContext) // default template: { selector: '#app'}
 
 - `context` (required): The Regor context or scope that defines the application's behavior and data.
 
-- `templateOptions` (optional): An HTML string or an object specifying the template for rendering the application. This can include the root element's selector, element reference, HTML content, JSON structure, and SVG indication.
+- `template` (optional): An HTML string or an object specifying the template for rendering the application. This can include the root element's selector, element reference, HTML content, JSON structure, and SVG indication.
 
 - `config` (optional): An optional configuration object that customizes Regor's behavior. It allows you to specify various options.
 
@@ -59,7 +59,7 @@ The `createApp` function returns an object with the following properties:
 
 - The `context` parameter defines the behavior and data of your application, allowing you to create reactive components and composable logic.
 
-- The `templateOptions` parameter allows you to specify how the initial content or structure of the application should be rendered.
+- The `template` parameter allows you to specify how the initial content or structure of the application should be rendered.
 
 - The `config` parameter lets you customize Regor's behavior to suit your application's requirements.
 

--- a/docs/api/createComponent.md
+++ b/docs/api/createComponent.md
@@ -12,7 +12,7 @@ To create a Regor component, call the `createComponent` function with the follow
 
 - `context` (required): A function that defines the Regor context for the component. This function receives a `ComponentHead` object, which you can use to specify the component's behavior and props. It should return the Regor context.
 
-- `templateOptions` (required): An HTML string or an object specifying the template for rendering the component. It can include the following properties:
+- `template` (required): An HTML string or an object specifying the template for rendering the component. It can include the following properties:
 
   - `selector` (string, optional): A CSS selector string for the root element of the component. Regor will attempt to find this element in the DOM.
   - `element` (Element, optional): A reference to the root DOM element of the component. If provided, this element will be used as the component's template.
@@ -46,7 +46,7 @@ createApp({
 
 - `context` (required): A function that defines the Regor context for the component. It should return the Regor context, which specifies the component's behavior and data.
 
-- `templateOptions` (required): An HTML string or an object specifying the template for rendering the component. It defines the component's UI structure, either by selecting an existing DOM element or providing HTML content or a JSON structure.
+- `template` (required): An HTML string or an object specifying the template for rendering the component. It defines the component's UI structure, either by selecting an existing DOM element or providing HTML content or a JSON structure.
 
 - `options` (optional): An array of strings that defines component properties or an object that configures various options for the component, including whether to use interpolation, props, or the component's default name.
 
@@ -70,7 +70,7 @@ The `createComponent` function returns a component object with the following pro
 
 - The `context` parameter defines the behavior and data of your component.
 
-- The `templateOptions` parameter specifies how the component's UI is rendered. You can select an existing element in the DOM, provide HTML content, or use a JSON structure to define the component's structure.
+- The `template` parameter specifies how the component's UI is rendered. You can select an existing element in the DOM, provide HTML content, or use a JSON structure to define the component's structure.
 
 - The `options` parameter allows you to configure various aspects of the component, such as enabling or disabling interpolation, specifying props, or setting a default name.
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -242,7 +242,7 @@ export interface JSONTemplate {
  * If used with 'createComponent':
  * - Define only one option: 'selector', 'element', 'html', or 'json'. The single option defines the component's HTML template.
  */
-export interface TemplateOptions {
+export interface Template {
   /**
    * If used with 'createApp', specifies the target root element for mounting the application.
    * If used with 'createComponent', identifies the component template using a selector.

--- a/src/app/createApp.ts
+++ b/src/app/createApp.ts
@@ -2,7 +2,7 @@ import { ErrorType, getError } from '../log/errors'
 import {
   type Scope,
   type IRegorContext,
-  type TemplateOptions,
+  type Template,
   type App,
 } from '../api/types'
 import { Binder } from '../bind/Binder'
@@ -21,16 +21,16 @@ import { isString } from '../common/is-what'
 
 export const createApp = <TRegorContext extends IRegorContext>(
   context: TRegorContext | Scope<TRegorContext>,
-  templateOptions: TemplateOptions | string = { selector: '#app' },
+  template: Template | string = { selector: '#app' },
   config?: RegorConfig,
 ): App<TRegorContext> => {
-  if (isString(templateOptions))
-    templateOptions = { selector: '#app', template: templateOptions }
+  if (isString(template))
+    template = { selector: '#app', template }
   if (isScope(context)) context = context.context
-  const root = templateOptions.element
-    ? templateOptions.element
-    : templateOptions.selector
-    ? document.querySelector(templateOptions.selector)
+  const root = template.element
+    ? template.element
+    : template.selector
+    ? document.querySelector(template.selector)
     : null
   if (!root || !isElement(root)) throw getError(ErrorType.AppRootElementMissing)
   if (!config) config = RegorConfig.getDefault()
@@ -46,17 +46,17 @@ export const createApp = <TRegorContext extends IRegorContext>(
     }
   }
 
-  if (templateOptions.template) {
+  if (template.template) {
     const element = document
       .createRange()
-      .createContextualFragment(templateOptions.template)
+      .createContextualFragment(template.template)
     cleanRoot()
     appendChildren(element.childNodes)
-    templateOptions.element = element
-  } else if (templateOptions.json) {
+    template.element = element
+  } else if (template.json) {
     const element = toFragment(
-      templateOptions.json,
-      templateOptions.isSVG,
+      template.json,
+      template.isSVG,
       config,
     )
     cleanRoot()

--- a/src/app/createComponent.ts
+++ b/src/app/createComponent.ts
@@ -2,7 +2,7 @@ import {
   type CreateComponentOptions,
   type Component,
   type IRegorContext,
-  type TemplateOptions,
+  type Template,
 } from '../api/types'
 import { ErrorType, getError } from '../log/errors'
 import { type ComponentHead } from './ComponentHead'
@@ -15,56 +15,56 @@ import { isArray, isString } from '../common/is-what'
 
 export const createComponent = <TProps = Record<any, any>>(
   context: (head: ComponentHead<TProps>) => IRegorContext,
-  templateOptions: TemplateOptions | string,
+  template: Template | string,
   options: CreateComponentOptions | string[] = {},
 ): Component<TProps> => {
   if (isArray(options)) options = { props: options }
-  if (isString(templateOptions)) templateOptions = { template: templateOptions }
+  if (isString(template)) template = { template }
   let svgHandled = false
-  if (templateOptions.element) {
-    const element = templateOptions.element as ChildNode
+  if (template.element) {
+    const element = template.element as ChildNode
     element.remove()
-    templateOptions.element = element
-  } else if (templateOptions.selector) {
-    const element = document.querySelector(templateOptions.selector)
+    template.element = element
+  } else if (template.selector) {
+    const element = document.querySelector(template.selector)
     if (!element)
       throw getError(
         ErrorType.ComponentTemplateNotFound,
-        templateOptions.selector,
+        template.selector,
       )
     element.remove()
-    templateOptions.element = element
-  } else if (templateOptions.template) {
+    template.element = element
+  } else if (template.template) {
     const element = document
       .createRange()
-      .createContextualFragment(templateOptions.template)
-    templateOptions.element = element
-  } else if (templateOptions.json) {
-    templateOptions.element = toFragment(
-      templateOptions.json,
-      templateOptions.isSVG,
+      .createContextualFragment(template.template)
+    template.element = element
+  } else if (template.json) {
+    template.element = toFragment(
+      template.json,
+      template.isSVG,
       options.config,
     )
     svgHandled = true
   }
-  if (!templateOptions.element)
-    templateOptions.element = document.createDocumentFragment()
-  if (options.useInterpolation ?? true) interpolate(templateOptions.element)
-  const element = templateOptions.element
+  if (!template.element)
+    template.element = document.createDocumentFragment()
+  if (options.useInterpolation ?? true) interpolate(template.element)
+  const element = template.element
   if (
     !svgHandled &&
-    ((templateOptions.isSVG ??
+    ((template.isSVG ??
       (isHTMLElement(element) && element.hasAttribute?.('isSVG'))) ||
       (isHTMLElement(element) && !!element.querySelector('[isSVG]')))
   ) {
-    const content = (templateOptions.element as any).content
+    const content = (template.element as any).content
     const nodes = content ? [...content.childNodes] : [...element.childNodes]
     const json = toJsonTemplate(nodes as Element[])
-    templateOptions.element = toFragment(json, true, options.config)
+    template.element = toFragment(json, true, options.config)
   }
   return {
     context,
-    template: templateOptions.element,
+    template: template.element,
     inheritAttrs: options.inheritAttrs ?? true,
     props: options.props,
     defaultName: options.defaultName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,6 @@ export type {
   OnCleanup,
   OnMounted,
   OnUnmounted,
-  TemplateOptions as Template,
+  Template,
   UnwrapRef,
 } from './api/types'


### PR DESCRIPTION
## Summary
- rename `TemplateOptions` variable usage to `template`
- update docs mentioning the parameter name

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684a5924a4388328bc6f387f5e079322