### PR TITLE
Add tests for exported utilities

### DIFF
--- a/tests/app/toFragment.spec.ts
+++ b/tests/app/toFragment.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from 'vitest'
+import { toFragment, toJsonTemplate } from '../../src'
+
+const json = { t: 'div', a: { id: 'foo' }, c: [{ t: 'span', c: [{ d: 'hi' }] }] }
+
+test('json to fragment and back', () => {
+  const fragment = toFragment(json)
+  const div = fragment.firstElementChild as Element
+  expect(div.tagName).toBe('DIV')
+  expect(div.querySelector('span')?.textContent).toBe('hi')
+  const back = toJsonTemplate(div)
+  expect(back).toEqual({ t: 'DIV', a: { id: 'foo' }, c: [{ t: 'SPAN', c: [{ d: 'hi' }] }] })
+})
+
+test('svg conversion', () => {
+  const svgJson = { t: 'svg', a: { width: '10' }, c: [{ t: 'circle', a: { r: '5' } }] }
+  const frag = toFragment(svgJson, true)
+  const svg = frag.firstElementChild as SVGElement
+  expect(svg.namespaceURI).toBe('http://www.w3.org/2000/svg')
+  const json2 = toJsonTemplate(svg)
+  expect(json2.t).toBe('svg')
+})

--- a/tests/cleanup/cleanup.spec.ts
+++ b/tests/cleanup/cleanup.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test, vi } from 'vitest'
+import { addUnbinder, getBindData, removeNode, unbind } from '../../src'
+
+ test('addUnbinder and unbind', () => {
+  const el = document.createElement('div')
+  const bd = getBindData(el)
+  const fn = vi.fn()
+  addUnbinder(el, fn)
+  expect(getBindData(el)).toBe(bd)
+  expect(bd.unbinders.length).toBe(1)
+  unbind(el)
+  expect(fn).toHaveBeenCalledTimes(1)
+  expect(bd.unbinders.length).toBe(0)
+ })
+
+test('removeNode removes and unbinds', () => {
+  vi.useFakeTimers()
+  const parent = document.createElement('div')
+  const child = document.createElement('span')
+  parent.appendChild(child)
+  const fn = vi.fn()
+  addUnbinder(child, fn)
+  removeNode(child)
+  expect(parent.contains(child)).toBe(false)
+  vi.runAllTimers()
+  expect(fn).toHaveBeenCalledTimes(1)
+  vi.useRealTimers()
+})

--- a/tests/composition/hooks.spec.ts
+++ b/tests/composition/hooks.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test, vi } from 'vitest'
+import { onMounted, onUnmounted, useScope } from '../../src'
+import { callMounted } from '../../src/composition/callMounted'
+import { callUnmounted } from '../../src/composition/callUnmounted'
+
+ test('mounted and unmounted callbacks run', () => {
+  const m = vi.fn()
+  const u = vi.fn()
+  const scope = useScope(() => {
+    onMounted(m)
+    onUnmounted(u)
+    return {}
+  })
+  callMounted(scope.context)
+  expect(m).toHaveBeenCalledTimes(1)
+  callUnmounted(scope.context)
+  expect(u).toHaveBeenCalledTimes(1)
+ })

--- a/tests/computed/compute.spec.ts
+++ b/tests/computed/compute.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest'
+import { computeMany, computeRef, ref } from '../../src'
+
+test('computeMany sums refs', () => {
+  const r1 = ref(1)
+  const r2 = ref(2)
+  const c = computeMany([r1, r2], (a, b) => a + b)
+  expect(c()).toBe(3)
+  r1(2)
+  expect(c()).toBe(4)
+})
+
+test('computeRef computes from ref', () => {
+  const r = ref(2)
+  const c = computeRef(r, v => v * 3)
+  expect(c()).toBe(6)
+  r(4)
+  expect(c()).toBe(12)
+})

--- a/tests/config/regor-config.spec.ts
+++ b/tests/config/regor-config.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test, vi } from 'vitest'
+import { RegorConfig, ComponentHead } from '../../src'
+
+test('getDefault returns singleton', () => {
+  expect(RegorConfig.getDefault()).toBe(RegorConfig.getDefault())
+})
+
+test('global context contains helpers', () => {
+  const cfg = new RegorConfig()
+  expect(typeof cfg.globalContext.ref).toBe('function')
+  expect(typeof cfg.globalContext.sref).toBe('function')
+  expect(typeof cfg.globalContext.flatten).toBe('function')
+})
+
+test('updateDirectives applies changes', () => {
+  const cfg = new RegorConfig()
+  cfg.updateDirectives((map, names) => { names.foo = 'r-foo'; map['r-foo'] = {} as any })
+  expect(cfg.__builtInNames.foo).toBe('r-foo')
+  expect('r-foo' in cfg.__directiveMap).toBe(true)
+})
+
+test('ComponentHead unmount removes nodes', () => {
+  const container = document.createElement('div')
+  const start = document.createComment('s')
+  const end = document.createComment('e')
+  const span = document.createElement('span')
+  container.append(start, span, end)
+  const head = new ComponentHead({}, container, [{}], start, end)
+  const fn = vi.fn()
+  ;(head as any).unmounted = fn
+  head.unmount()
+  expect(container.contains(span)).toBe(false)
+  expect(fn).toHaveBeenCalledTimes(1)
+})

--- a/tests/misc/raw.spec.ts
+++ b/tests/misc/raw.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from 'vitest'
+import { isRaw, markRaw } from '../../src'
+
+test('markRaw marks object', () => {
+  const obj = markRaw({})
+  expect(isRaw(obj)).toBe(true)
+  expect(isRaw({})).toBe(false)
+})

--- a/tests/observer/observeMany.spec.ts
+++ b/tests/observer/observeMany.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest'
+import { observeMany, observerCount, ref } from '../../src'
+
+test('observeMany reacts to multiple refs', () => {
+  const a = ref(1)
+  const b = ref(2)
+  let vals: number[] = []
+  const stop = observeMany([a, b], v => { vals = v }, true)
+  expect(vals).toEqual([1,2])
+  a(3)
+  expect(vals).toEqual([3,2])
+  b(5)
+  expect(vals).toEqual([3,5])
+  stop()
+})
+
+test('observerCount reflects observers', () => {
+  const a = ref(0)
+  expect(observerCount(a)).toBe(0)
+  const stop = observeMany([a], () => {})
+  expect(observerCount(a)).toBe(1)
+  stop()
+  expect(observerCount(a)).toBe(0)
+})

--- a/tests/reactivity/batch.spec.ts
+++ b/tests/reactivity/batch.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from 'vitest'
+import { batch, startBatch, endBatch, ref, watchEffect } from '../../src'
+
+test('batch triggers once', () => {
+  const a = ref(0)
+  let calls = 0
+  watchEffect(() => { a(); calls++ })
+  calls = 0
+  batch(() => {
+    a.value++
+    a.value++
+  })
+  expect(calls).toBe(1)
+})
+
+test('manual batch', () => {
+  const a = ref(0)
+  let calls = 0
+  watchEffect(() => { a(); calls++ })
+  calls = 0
+  startBatch()
+  a.value++
+  a.value++
+  expect(calls).toBe(0)
+  endBatch()
+  expect(calls).toBe(1)
+})

--- a/tests/reactivity/ref-utils.spec.ts
+++ b/tests/reactivity/ref-utils.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { ref, isDeepRef, pause, resume, entangle, watchEffect } from '../../src'
+import { ref, isDeepRef, pause, resume, entangle, watchEffect, isRef, sref, unref } from '../../src'
 
 test('pause and resume', () => {
   const r = ref(1)
@@ -42,5 +42,5 @@ test('unref unwraps refs and returns value', () => {
   const sr = sref(3)
   expect(unref(r)).toBe(2)
   expect(unref(sr)).toBe(3)
-  expect(unref(4)).toBe(4
+  expect(unref(4)).toBe(4)
 })

--- a/tests/reactivity/ref-utils.spec.ts
+++ b/tests/reactivity/ref-utils.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'vitest'
+import { ref, isDeepRef, pause, resume, entangle, watchEffect } from '../../src'
+
+test('isDeepRef detects deep refs', () => {
+  const r = ref({ a: 1 })
+  expect(isDeepRef(r)).toBe(true)
+  expect(isDeepRef(r())).toBe(false)
+})
+
+test('pause and resume', () => {
+  const r = ref(1)
+  let n = 0
+  watchEffect(() => { r(); n++ })
+  expect(n).toBe(1)
+  pause(r)
+  r(2)
+  expect(n).toBe(1)
+  resume(r)
+  r(3)
+  expect(n).toBe(2)
+})
+
+test('entangle syncs refs', () => {
+  const r1 = ref(1)
+  const r2 = ref(0)
+  const stop = entangle(r1, r2)
+  expect(r2()).toBe(1)
+  r1(2)
+  expect(r2()).toBe(2)
+  r2(3)
+  expect(r1()).toBe(3)
+  stop()
+  r1(4)
+  expect(r2()).toBe(3)
+})


### PR DESCRIPTION
## Summary
- add test suites for utility functions missing coverage
- test conversion helpers, cleanup handlers, computed utilities, observers
- cover batch operations, ref utils, composition hooks, raw markers
- verify RegorConfig behaviors and ComponentHead unmount

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684a8771ef94832894caf39de604c731