### PR TITLE
Fix docs links and add docs-site README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ Regor is a powerful UI framework designed to streamline the development of HTML5
 
 Discover the capabilities of Regor by diving into our comprehensive documentation. Whether you're new to Regor or an experienced user, our documentation provides in-depth insights into its features, API, directives, and more.
 
-Start exploring the [Regor Documentation](docs/index.md) now to harness the full potential of this powerful UI framework.
+
+Start exploring the [Regor Documentation](https://tenray.io/regor) now to harness the full potential of this powerful UI framework. The documentation sources are located in [docs-site](docs-site/).
+
+## Requirements
+
+Regor is developed using Node.js 18 and Yarn. Ensure you have Node.js 18 or newer installed before running the examples or the documentation site.
 
 ## Getting started
 

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,0 +1,25 @@
+# Regor Documentation Site
+
+This directory contains the source for Regor's documentation built with [Astro](https://astro.build/) and the Starlight theme.
+
+## Requirements
+
+- Node.js 18 or newer
+- Yarn (v4)
+
+## Getting Started
+
+Install dependencies and start a local server:
+
+```bash
+yarn install
+yarn dev
+```
+
+To create a production build:
+
+```bash
+yarn build
+```
+
+The generated site will be written to `docs-dist/`.

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -11,17 +11,10 @@ Welcome to the documentation for Regor, a powerful UI framework designed to stre
 - [Supported Directives](directives/directives.md): Explore the directives provided by Regor for building dynamic user interfaces.
 - [Regor API](api/regor-api.md): Dive into the details of the Regor API and its various functions.
 
-If you have any questions or need further assistance, feel free to [join our community](#).
-
-**Table of Contents:**
-
-- [Overview](overview.md)
-- [Getting Started](getting-started.md)
-- [Supported Directives](directives/directives.md)
-- [Regor API](api/regor-api.md)
+If you have any questions or need further assistance, feel free to [join our community](https://github.com/koculu/regor/discussions).
 
 ---
 
-**Note**: Regor is an open-source project, and your contributions are greatly appreciated. Help us make Regor even better by [contributing](../../../../.github/CONTRIBUTING.md) or [reporting issues](#issues).
+**Note**: Regor is an open-source project, and your contributions are greatly appreciated. Help us make Regor even better by [contributing](../../../../.github/CONTRIBUTING.md) or [reporting issues](https://github.com/koculu/regor/issues).
 
 [Back to GitHub Repository](https://github.com/koculu/Regor)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,26 +2,11 @@
 title: Regor Documentation
 ---
 
-# Regor Documentation
+# Documentation Relocated
 
-Welcome to the documentation for Regor, a powerful UI framework designed to streamline the development of HTML5-based applications for both web and desktop environments.
+The documentation has moved to [docs-site/src/content/docs/index.md](../docs-site/src/content/docs/index.md).
+Please update your bookmarks.
 
-- [Overview](../docs-site/verview.md): Learn about what Regor is and its key features.
-- [Getting Started](../docs-site/getting-started.md): Get started with Regor by creating your first application.
-- [Supported Directives](../docs-site/directives/directives.md): Explore the directives provided by Regor for building dynamic user interfaces.
-- [Regor API](../docs-site/api/regor-api.md): Dive into the details of the Regor API and its various functions.
-
-If you have any questions or need further assistance, feel free to [join our community](#).
-
-**Table of Contents:**
-
-- [Overview](../docs-site/overview.md)
-- [Getting Started](../docs-site/getting-started.md)
-- [Supported Directives](../docs-site/directives/directives.md)
-- [Regor API](../docs-site/api/regor-api.md)
-
----
-
-**Note**: Regor is an open-source project, and your contributions are greatly appreciated. Help us make Regor even better by [contributing](../.github/CONTRIBUTING.md) or [reporting issues](#issues).
+You can also read it online at [https://tenray.io/regor](https://tenray.io/regor).
 
 [Back to GitHub Repository](https://github.com/koculu/Regor)


### PR DESCRIPTION
## Summary
- replace docs/index.md with relocation note
- clean up docs index and fix broken links
- document how to run the docs site
- link README to the hosted docs and note Node.js requirement

## Testing
- `yarn lint` *(fails: ESLint couldn't find a config)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684a7e6cff7083289c7ef7d5fe871651