### PR TITLE
Fix flatten map iteration bug

### DIFF
--- a/src/misc/flatten.ts
+++ b/src/misc/flatten.ts
@@ -28,7 +28,7 @@ const flattenContent = (value: any): any => {
   }
   if (isMap(value)) {
     const map = new Map<unknown, unknown>()
-    for (const el of map) {
+    for (const el of value) {
       map.set(flatten(el[0]), flatten(el[1]))
     }
     return map

--- a/tests/misc/utils.spec.ts
+++ b/tests/misc/utils.spec.ts
@@ -13,7 +13,7 @@ test('flatten converts nested refs', () => {
 
   const map = ref(new Map([['k', ref(4)]]))
   const flatMap = flatten(map) as Map<string, any>
-  expect(flatMap.get('k')).toBeUndefined()
+  expect(flatMap.get('k')).toBe(4)
 })
 
 test('markRaw marks object as raw', () => {


### PR DESCRIPTION
## Summary
- fix map iteration in `flatten` utility to iterate source map
- update utils test to ensure maps are flattened

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684aa356308c83289984adf5e8a86f08