### PR TITLE
Fix docs link in README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
     paths-ignore:
       - '*.md'
 jobs:
-  build-and-publish:
+  build-and-test:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Regor is a powerful UI framework designed to streamline the development of HTML5
 Discover the capabilities of Regor by diving into our comprehensive documentation. Whether you're new to Regor or an experienced user, our documentation provides in-depth insights into its features, API, directives, and more.
 
 
-Start exploring the [Regor Documentation](https://tenray.io/regor) now to harness the full potential of this powerful UI framework. The documentation sources are located in [docs-site](docs-site/).
+Start exploring the [Regor Documentation](https://tenray.io/projects/regor) now to harness the full potential of this powerful UI framework. The documentation sources are located in [docs-site](docs-site/).
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- correct link to documentation site in README
- job name in test workflow clarified from `build-and-publish` to `build-and-test`

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684aa32c283c83289375aff61a49b6c0