### PR TITLE
Fix int flag handling in r-model

### DIFF
--- a/src/directives/model.ts
+++ b/src/directives/model.ts
@@ -141,7 +141,7 @@ const attachDOMChangeListener = (
   const f1 = getFlags(directiveFlags?.join(','))
   const f2 = getFlags(parsedValue()[1])
   const flags: ModelFlags = {
-    int: f1.int || f1.int,
+    int: f1.int || f2.int,
     lazy: f1.lazy || f2.lazy,
     number: f1.number || f2.number,
     trim: f1.trim || f2.trim,

--- a/tests/directives/model.spec.ts
+++ b/tests/directives/model.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+import { createApp, ref, html } from '../../src'
+
+test('r-model expression flag int converts input to integer', () => {
+  const root = document.createElement('div')
+  const count = ref(0)
+  createApp(
+    { count },
+    { element: root, template: html`<input r-model="count, 'int'" />` },
+  )
+  const input = root.querySelector('input') as HTMLInputElement
+  input.value = '7.8'
+  input.dispatchEvent(new Event('input'))
+  expect(count()).toBe(7)
+})


### PR DESCRIPTION
## Summary
- fix boolean aggregation in `model` directive
- add regression test for r-model int flag

## Testing
- `yarn test --run`

------
https://chatgpt.com/codex/tasks/task_e_684ab903e60483289ef9d76fe648170a