### PR TITLE
Fix class directive boolean removal

### DIFF
--- a/src/directives/class.ts
+++ b/src/directives/class.ts
@@ -35,7 +35,7 @@ const patchClass = (el: HTMLElement, next: Class, prev: Class): void => {
   if (next && !isClassString) {
     if (prev && !isPrevClassString) {
       for (const key in prev) {
-        if (!(key in next)) {
+        if (!(key in next) || !next[key]) {
           classList.remove(key)
         }
       }

--- a/tests/directives/class.spec.ts
+++ b/tests/directives/class.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest'
+import { createApp, html, ref } from '../../src'
+
+test('class directive toggles classes', () => {
+  const root = document.createElement('div')
+  const app = createApp(
+    {
+      activeTab: ref('app'),
+    },
+    {
+      element: root,
+      template: html`<div>
+        <div id="app" :class="{ active: activeTab === 'app' }"></div>
+        <div id="js" :class="{ active: activeTab === 'js' }"></div>
+        <div id="ts" :class="{ active: activeTab === 'ts' }"></div>
+      </div>`,
+    },
+  )
+  expect(root.querySelector('#app')?.classList.contains('active')).toBe(true)
+  expect(root.querySelector('#js')?.classList.contains('active')).toBe(false)
+  expect(root.querySelector('#ts')?.classList.contains('active')).toBe(false)
+  app.context.activeTab('js')
+  expect(root.querySelector('#app')?.classList.contains('active')).toBe(false)
+  expect(root.querySelector('#js')?.classList.contains('active')).toBe(true)
+  expect(root.querySelector('#ts')?.classList.contains('active')).toBe(false)
+})


### PR DESCRIPTION
## Summary
- handle falsy boolean flags when unpatching previous classes
- add a regression test for class directive toggling

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684ac5320ed0832887d3d8afa2b571de