### PR TITLE
Support destructuring in r-for

### DIFF
--- a/docs-site/src/content/docs/directives/r-for.md
+++ b/docs-site/src/content/docs/directives/r-for.md
@@ -64,22 +64,22 @@ In this example, the `r-for` directive generates a numbered list of fruits, disp
 You can use the `r-for` directive to iterate over the properties of an object.
 
 ```html
-<element r-for="(value, key) in object">
-  <!-- 'value' and 'key' variables -->
+<element r-for="(key, value) in object">
+  <!-- 'key' and 'value' variables -->
   <!-- Content to be repeated for each property -->
   {{ key }}: {{ value }}
 </element>
 ```
 
-- `value`: Represents the current property's value.
 - `key`: Represents the current property's key (name).
+- `value`: Represents the current property's value.
 - `object`: An object whose properties are iterated over.
 
 ### Example
 
 ```html
 <ul>
-  <li r-for="(value, key) in person">{{ key }}: {{ value }}</li>
+  <li r-for="(key, value) in person">{{ key }}: {{ value }}</li>
 </ul>
 ```
 

--- a/tests/directives/r-for.spec.ts
+++ b/tests/directives/r-for.spec.ts
@@ -112,3 +112,83 @@ test('should mount nested r-for.', () => {
   duplicate(0)
   testContent()
 })
+
+test('should iterate using of syntax', () => {
+  const root = document.createElement('div')
+  createApp(
+    {
+      fruits: ref(['Apple', 'Banana']),
+    },
+    {
+      element: root,
+      template: html`<div r-for="fruit of fruits">{{ fruit }}</div>`,
+    },
+  )
+  expect([...root.querySelectorAll('div')].map((x) => x.textContent)).toStrictEqual([
+    'Apple',
+    'Banana',
+  ])
+})
+
+test('should support index variable with parentheses', () => {
+  const root = document.createElement('div')
+  createApp(
+    {
+      fruits: ref(['Apple', 'Banana']),
+    },
+    {
+      element: root,
+      template: html`<div r-for="(fruit, #i) in fruits">{{ i }} - {{ fruit }}</div>`,
+    },
+  )
+  expect([...root.querySelectorAll('span')].map((x) => x.textContent)).toStrictEqual([
+    '0',
+    'Apple',
+    '1',
+    'Banana',
+  ])
+})
+
+test('should iterate object properties', () => {
+  const root = document.createElement('div')
+  createApp(
+    {
+      person: ref({ name: 'Alice', age: 25 }),
+    },
+    {
+      element: root,
+      template: html`<div r-for="(key, value) in person">{{ key }}: {{ value }}</div>`,
+    },
+  )
+  expect([...root.querySelectorAll('span')].map((x) => x.textContent)).toStrictEqual([
+    'name',
+    'Alice',
+    'age',
+    '25',
+  ])
+})
+
+test('should support object destructuring with index', () => {
+  const root = document.createElement('div')
+  createApp(
+    {
+      users: ref([
+        { name: 'Alice', age: 25 },
+        { name: 'Bob', age: 30 },
+      ]),
+    },
+    {
+      element: root,
+      template: html`<div r-for="{ name, age }, #index in users">{{ index }} - {{ name }} - {{ age }}</div>`,
+    },
+  )
+  expect([...root.querySelectorAll('span')].map((x) => x.textContent)).toStrictEqual([
+    '0',
+    'Alice',
+    '25',
+    '1',
+    'Bob',
+    '30',
+  ])
+})
+


### PR DESCRIPTION
## Summary
- revert previous destructuring implementation
- add tests for documented r-for patterns
- fix key-value order in docs and tests

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_684acfd2aad88328a4d33c4869e0adc2