### PR TITLE
Improve r-for regex to parse complex expressions

### DIFF
--- a/docs-site/src/content/docs/directives/r-for.md
+++ b/docs-site/src/content/docs/directives/r-for.md
@@ -127,6 +127,17 @@ You can use either `of` or `in` to specify the iteration variable and the iterab
 </element>
 ```
 
+## Complex Expressions
+
+You can pass any JavaScript expression after `in` or `of`. This allows using
+helpers like `filter` directly within the directive.
+
+```html
+<ul>
+  <li r-for="n in numbers.filter(n => n > 5)">{{ n }}</li>
+</ul>
+```
+
 ## Key Attribute
 
 When iterating over lists of items, it's important to provide a unique `key` attribute to help Regor efficiently track and update elements. The `key` attribute should be applied to the repeated element, and its value should be unique for each item in the iterable.

--- a/src/bind/ForBinder.ts
+++ b/src/bind/ForBinder.ts
@@ -283,7 +283,7 @@ export class ForBinder {
   }
 
   static __forPathRegex =
-    /\{?\[?\(?([^)}\]]+)\)?\]?\}?([^)]+)?\s+\b(?:in|of)\b\s+([^\s]+)\s*/
+    /\{?\[?\(?([^)}\]]+)\)?\]?\}?([^)]+)?\s+\b(?:in|of)\b\s+(.*)\s*$/
 
   __parseForPath(forPath: string):
     | {

--- a/tests/directives/r-for.spec.ts
+++ b/tests/directives/r-for.spec.ts
@@ -192,3 +192,20 @@ test('should support object destructuring with index', () => {
   ])
 })
 
+test('should handle expressions with spaces', () => {
+  const root = document.createElement('div')
+  createApp(
+    {
+      numbers: ref([1, 2, 3, 4, 5, 6]),
+    },
+    {
+      element: root,
+      template: html`<div r-for="n in numbers.filter(n => n > 4 )">{{ n }}</div>`,
+    },
+  )
+  expect([...root.querySelectorAll('div')].map((x) => x.textContent)).toStrictEqual([
+    '5',
+    '6',
+  ])
+})
+


### PR DESCRIPTION
## Summary
- adjust `ForBinder.__forPathRegex` to capture entire expression
- document that r-for works with complex expressions
- add regression test for expression with spaces

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684afbaf9c248328a9bc4a506d2c18a8