### PR TITLE
Fix r-for valueMap for falsy keys

### DIFF
--- a/src/bind/MountList.ts
+++ b/src/bind/MountList.ts
@@ -24,12 +24,12 @@ export class MountList {
 
   __setValueMap(item: MountListItem): void {
     const value = this.__getKey(item.value)
-    if (value) this.__valueMap.set(value, item)
+    if (value !== undefined) this.__valueMap.set(value, item)
   }
 
   __deleteValueMap(index: number): void {
     const value = this.__getKey(this.__list[index]?.value)
-    if (value) this.__valueMap.delete(value)
+    if (value !== undefined) this.__valueMap.delete(value)
   }
 
   /**


### PR DESCRIPTION
## Summary
- ensure MountList valueMap accepts falsy keys
- test r-for with falsy list values keyed by id

## Testing
- `yarn test --run`


------
https://chatgpt.com/codex/tasks/task_e_684af9483ad083288ec97eda498d924e