### PR TITLE
Add missing tests for watchEffect utilities and warnings

### DIFF
--- a/tests/computed/watchEffect.spec.ts
+++ b/tests/computed/watchEffect.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from 'vitest'
+import { watchEffect, silence, collectRefs, ref } from '../../src'
+
+// silence should prevent watchEffect from tracking refs
+
+test('silence prevents tracking refs in watchEffect', () => {
+  const r = ref(0)
+  let calls = 0
+  watchEffect(() => {
+    calls++
+    silence(() => r())
+  })
+  expect(calls).toBe(1)
+  r.value = 1
+  expect(calls).toBe(1)
+})
+
+// collectRefs should capture accessed refs and return value
+
+test('collectRefs gathers refs and returns value', () => {
+  const a = ref(1)
+  const b = ref(2)
+  const { value, refs } = collectRefs(() => a() + b())
+  expect(value).toBe(3)
+  expect(refs).toContain(a)
+  expect(refs).toContain(b)
+  expect(refs.length).toBe(2)
+})

--- a/tests/log/warningHandler.spec.ts
+++ b/tests/log/warningHandler.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test, vi } from 'vitest'
+import { warningHandler } from '../../src'
+import { warning, WarningType } from '../../src/log/warnings'
+
+test('warningHandler can be overridden', () => {
+  const spy = vi.fn()
+  const prev = warningHandler.warning
+  warningHandler.warning = spy
+  const el = document.createElement('div')
+  warning(WarningType.MissingBindingExpression, 'r-text', el)
+  expect(spy).toHaveBeenCalled()
+  warningHandler.warning = prev
+})


### PR DESCRIPTION
## Summary
- add unit tests for `silence` and `collectRefs`
- add coverage for `warningHandler`

## Testing
- `yarn test --run`

------
https://chatgpt.com/codex/tasks/task_e_684b04d7af388328a97778b186b445cf