### PR TITLE
Fix observerCount error name

### DIFF
--- a/src/observer/observerCount.ts
+++ b/src/observer/observerCount.ts
@@ -6,7 +6,7 @@ export const observerCount = <TValueType extends AnyRef>(
   source: TValueType,
 ): number => {
   if (!isRef(source))
-    throw getError(ErrorType.RequiresRefSourceArgument, 'observe')
+    throw getError(ErrorType.RequiresRefSourceArgument, 'observerCount')
   const srefImpl = source as unknown as SRefSignature<TValueType>
   return srefImpl(undefined, undefined, RefOperation.observerCount) as number
 }


### PR DESCRIPTION
## Summary
- ensure `observerCount` references itself when `Ref` source is missing

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684b33fb8ca48328836db1201437a427