### PR TITLE
Handle persist parse errors

### DIFF
--- a/src/misc/persist.ts
+++ b/src/misc/persist.ts
@@ -3,6 +3,7 @@ import { type AnyRef } from '../api/types'
 import { onUnmounted } from '../composition/onUnmounted'
 import { isDeepRef } from '../reactivity/isDeepRef'
 import { ErrorType, getError } from '../log/errors'
+import { warning, WarningType } from '../log/warnings'
 
 export const persist = <TRef extends AnyRef>(
   anyRef: TRef,
@@ -15,7 +16,16 @@ export const persist = <TRef extends AnyRef>(
     localStorage.setItem(key, JSON.stringify(flatten(anyRef())))
   const existing = localStorage.getItem(key)
   if (existing != null) {
-    anyRef(makeRef(JSON.parse(existing)))
+    try {
+      anyRef(makeRef(JSON.parse(existing)))
+    } catch (e) {
+      warning(
+        WarningType.ErrorLog,
+        `persist: failed to parse data for key ${key}`,
+        e as Error,
+      )
+      store()
+    }
   } else {
     store()
   }

--- a/tests/misc/persist.spec.ts
+++ b/tests/misc/persist.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from 'vitest'
-import { persist, ref } from '../../src'
+import { expect, test, vi } from 'vitest'
+import { persist, ref, warningHandler } from '../../src'
 import { ErrorType, getError } from '../../src/log/errors'
 
 const KEY = 'persist-key'
@@ -17,6 +17,20 @@ test('should persist value changes and restore existing data', () => {
   const r2 = ref(0)
   persist(r2, KEY)
   expect(r2.value).toBe(2)
+})
+
+test('should reset storage on invalid data', () => {
+  localStorage.clear()
+  localStorage.setItem(KEY, '[')
+  const spy = vi.fn()
+  const prev = warningHandler.warning
+  warningHandler.warning = spy
+  const r = ref(5)
+  persist(r, KEY)
+  expect(localStorage.getItem(KEY)).toBe('5')
+  expect(r.value).toBe(5)
+  expect(spy).toHaveBeenCalled()
+  warningHandler.warning = prev
 })
 
 // Validate that a key is required


### PR DESCRIPTION
## Summary
- reset persisted values when JSON.parse fails
- test handling of bad data in localStorage

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684b340224088328866f62623bcdccd4