### PR TITLE
Implement nested batch stack

### DIFF
--- a/src/reactivity/sref.ts
+++ b/src/reactivity/sref.ts
@@ -21,7 +21,7 @@ import { srefSymbol } from './refSymbols'
  * @internal
  */
 export const batchCollector: {
-  set?: Set<AnyRef>
+  stack?: Array<Set<AnyRef>>
 } = {}
 
 /**
@@ -84,8 +84,9 @@ export const sref = <TValueType>(
   const isProxy = createProxy(value)
   const observers = new Set<ObserveCallback<TValueType>>()
   const trigger = (newValue: TValueType, eventSource: any): void => {
-    if (batchCollector.set) {
-      batchCollector.set.add(srefFunction as unknown as AnyRef)
+    if (batchCollector.stack && batchCollector.stack.length) {
+      const current = batchCollector.stack[batchCollector.stack.length - 1]
+      current.add(srefFunction as unknown as AnyRef)
       return
     }
     if (observers.size === 0) return

--- a/tests/reactivity/batch.spec.ts
+++ b/tests/reactivity/batch.spec.ts
@@ -22,3 +22,33 @@ test('startBatch and endBatch delay triggers', () => {
   endBatch()
   expect(calls).toBe(1)
 })
+
+test('nested startBatch triggers after outer endBatch', () => {
+  const r1 = ref(0)
+  let calls1 = 0
+  observe(r1, () => ++calls1)
+
+  startBatch()
+  r1.value++
+  startBatch()
+  r1.value++
+  endBatch()
+  expect(calls1).toBe(0)
+  endBatch()
+  expect(calls1).toBe(1)
+})
+
+test('nested batch calls trigger once after outer batch', () => {
+  const r = ref(0)
+  let calls = 0
+  observe(r, () => ++calls)
+
+  batch(() => {
+    r.value++
+    batch(() => {
+      r.value++
+    })
+  })
+
+  expect(calls).toBe(1)
+})


### PR DESCRIPTION
## Summary
- support nested batching for refs
- add regression tests for nested batch logic

## Testing
- `yarn test --run`


------
https://chatgpt.com/codex/tasks/task_e_684b34147fd883289991d0ebc1a73e78