### PR TITLE
Fix class directive string splitting

### DIFF
--- a/src/directives/class.ts
+++ b/src/directives/class.ts
@@ -46,11 +46,11 @@ const patchClass = (el: HTMLElement, next: Class, prev: Class): void => {
   } else {
     if (isClassString) {
       if (prev !== next) {
-        if (isPrevClassString) classList.remove(...prev?.split(','))
-        classList.add(...next.split(','))
+        if (isPrevClassString) classList.remove(...prev.trim().split(/\s+/))
+        classList.add(...next.trim().split(/\s+/))
       }
     } else if (prev) {
-      if (isPrevClassString) classList.remove(...prev?.split(','))
+      if (isPrevClassString) classList.remove(...prev.trim().split(/\s+/))
     }
   }
 }

--- a/tests/directives/class.spec.ts
+++ b/tests/directives/class.spec.ts
@@ -24,3 +24,21 @@ test('class directive toggles classes', () => {
   expect(root.querySelector('#js')?.classList.contains('active')).toBe(true)
   expect(root.querySelector('#ts')?.classList.contains('active')).toBe(false)
 })
+
+test('class directive handles space-separated class lists', () => {
+  const root = document.createElement('div')
+  const cls = ref('a b')
+  createApp(
+    { cls },
+    { element: root, template: html`<div :class="cls"></div>` },
+  )
+  const div = root.querySelector('div') as HTMLDivElement
+  expect(div.classList.contains('a')).toBe(true)
+  expect(div.classList.contains('b')).toBe(true)
+  expect(div.classList.length).toBe(2)
+  cls('b c')
+  expect(div.classList.contains('a')).toBe(false)
+  expect(div.classList.contains('b')).toBe(true)
+  expect(div.classList.contains('c')).toBe(true)
+  expect(div.classList.length).toBe(2)
+})


### PR DESCRIPTION
## Summary
- handle whitespace-separated class lists in `patchClass`
- remove previous classes using the same delimiter
- test class directive with space-separated classes

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684b43d912808328913f36434594af00